### PR TITLE
Initial Travis, Coverage and package setup

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_first_party=altapay

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: python
+
+sudo: false
+
+env:
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=pypy
+  - TOXENV=pypy3
+
+matrix:
+  include:
+    - python: 3.5
+      env:
+      - TOXENV=py35
+
+install:
+  - pip install tox flake8 pep8-naming isort codecov
+
+before_script:
+  - isort -rc -cs --check-only altapay tests
+  - flake8 altapay tests
+
+script:
+  - tox
+
+after_success:
+  - codecov -e TOXENV

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include README.md
+include setup.py
+recursive-include docs *
+
+prune docs/_build
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-This is an unofficial Python SDK for AltaPay (formerly Pensio), https://altapay.com/. The SDK is maintained by Coolshop.com, https://www.coolshop.com/.
-
-**This is an incomplete, in-development version of the SDK. Do not use unless you know what you are doing**

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,40 @@
+.. image:: https://travis-ci.org/coolshop-com/AltaPay.svg
+    :target: https://travis-ci.org/coolshop-com/AltaPay
+.. image:: https://codecov.io/github/coolshop-com/AltaPay/coverage.svg?branch=master
+    :target: https://codecov.io/github/coolshop-com/AltaPay?branch=master
+
+This is an unofficial Python SDK for AltaPay (formerly Pensio), https://altapay.com/. The SDK is maintained by Coolshop.com, https://www.coolshop.com/.
+
+**This is an incomplete, in-development version of the SDK. Do not use unless you know what you are doing**
+
+Requirements
+============
+- Python (2.7, 3.3, 3.4, 3.5, pypy, pypy3)
+
+Other versions of Python may also be supported, but these are the only versions we test against.
+
+Installation
+============
+To come
+
+Getting Started
+===============
+To come
+
+Documentation
+=============
+To come
+
+Contributing
+============
+To come
+
+Running the Tests
+-----------------
+First of all, have `tox <http://tox.readthedocs.org/en/latest/>`_ installed on your system. System-wide is probably the better choice. Once you have tox installed, simply run:
+
+.. code:: python
+
+    tox
+
+This will run all tests, against all supported Python versions.

--- a/altapay/__init__.py
+++ b/altapay/__init__.py
@@ -1,0 +1,3 @@
+__version__ = '0.1.dev0'
+
+VERSION = __version__

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup, find_packages
+
+
+def get_version():
+    return __import__('altapay').VERSION
+
+
+version = get_version()
+
+with open('README.rst', 'r') as f:
+    long_description = f.read()
+
+
+setup(
+    name='altapay',
+    version=version,
+    url='https://github.com/coolshop-com/AltaPay',
+    license='MIT',
+    description='Unofficial Python SDK for AltaPay (formerly Pensio).',
+    long_description=long_description,
+    author='Coolshop.com',
+    author_email='altapaysdk@coolshop.com',
+    packages=find_packages(where='.', exclude=('tests*',)),
+    install_requires=[],
+    classifiers=[
+        'Development Status :: 1 - Planning',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3'
+    ])

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,0 +1,9 @@
+"""
+Test cases for testing of AltaPay SDK.
+
+Note that this module for now simply exposes the default Python unittest module
+test case classes, namely TestCase and SkipTest. At some point in the future,
+this module might expose different test cases with additional specific AltaPay
+functionality.
+"""
+from unittest import SkipTest, TestCase  # NOQA

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import, unicode_literals
+
+from .test_cases import TestCase
+
+
+class VersionTest(TestCase):
+    def test_module_version(self):
+        version = __import__('altapay').VERSION
+        self.assertGreater(len(version), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27,py33,py34,py35,pypy,pypy3
+
+[testenv]
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+deps =
+    nose
+    coverage
+commands =
+    nosetests --with-coverage


### PR DESCRIPTION
Initial Travis, Coverage and package setup

Initial package layout. Added tox and nose, and automatic checks using
Travis and coverage using Codecov.
Flake8, pep8-naming and isort in place.
Added dummy test case that checks against the version, to not have tests
fail with no tests.
Added basic README.