### PR TITLE
Add complex payments, tests and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,6 @@
 
 This is an unofficial Python SDK for AltaPay (formerly Pensio), https://altapay.com/. The SDK is maintained by Coolshop.com, https://www.coolshop.com/.
 
-**This is an incomplete, in-development version of the SDK. Do not use unless you know what you are doing**
-
 Documentation
 =============
 `Documentation is available at Read the Docs <http://altapay.readthedocs.org/en/latest/>`_.

--- a/altapay/__init__.py
+++ b/altapay/__init__.py
@@ -7,3 +7,7 @@ __api_base_url__ = {
     'test': 'https://testgateway.altapaysecure.com/merchant/',
     'production': 'https://{shop_name}.altapaysecure.com/merchant/'
 }
+
+from .api import API  # NOQA
+from .payment import Payment  # NOQA
+from .resource import Resource  # NOQA

--- a/altapay/exceptions.py
+++ b/altapay/exceptions.py
@@ -24,3 +24,9 @@ class ResponseStatusError(AltaPayException):
     the expected response status code.
     """
     pass
+
+
+class ServerError(AltaPayException):
+    """
+    Raised when an error in the 500 range is returned from the AltaPay service.
+    """

--- a/altapay/payment.py
+++ b/altapay/payment.py
@@ -12,6 +12,12 @@ class Payment(Resource):
         :arg shop_orderid: your order ID to be attached to the payment resource
         :arg amount: order amount in floating point
         :arg currency: currency for the payment resource
+        :arg \*\*kwargs: used for remaining, optional, payment request
+            parameters, see the AltaPay documentation for a full list.
+            Note that you will need to use lists and dictionaries to map the
+            URL structures from the AltaPay documentation into these kwargs.
+
+        :rtype: :samp:`True` if a payment was created, otherwise :samp:`False`.
         """
 
         parameters = {

--- a/altapay/resource.py
+++ b/altapay/resource.py
@@ -9,8 +9,7 @@ from . import utils
 
 class Resource(object):
     """
-    Base class that maps an XML document from AltaPay into a Python like
-    representation.
+    Base class that maps an AltaPay response into a Python like representation.
     """
     def __init__(self, version=None, header=None, body=None, api=None):
         self.__dict__['api'] = api  # TODO: Allow for global?
@@ -23,6 +22,18 @@ class Resource(object):
 
     @classmethod
     def create_from_response(cls, response):
+        """
+        Instantiate a new :py:class:`altapay.Resource` object from
+        a response.
+
+        :arg response: a response of type :samp:`dict`. The response most
+            conform to the AltaPay response format, which means it must carry
+            four keys called :samp:`@version`, :samp:`APIResponse`,
+            :samp:`Header` and :samp:`Body`.
+
+        :rtype: a new version object of type
+            :py:class:`altapay.Resource`.
+        """
         try:
             api_response = response['APIResponse']
             header = api_response['Header']

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -1,7 +1,9 @@
+.. _api-api:
+
 API
 ===
 
-.. py:module:: altapay.api
+.. py:module:: altapay
 
 .. autoclass:: API
     :members:

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -1,4 +1,4 @@
-.. _exceptions:
+.. _api-exceptions:
 
 Exceptions
 ==========

--- a/docs/api/payment.rst
+++ b/docs/api/payment.rst
@@ -1,0 +1,10 @@
+.. _api_payment:
+
+Payment
+=======
+
+.. py:module:: altapay
+
+.. autoclass:: Payment
+    :show-inheritance:
+    :members:

--- a/docs/api/resource.rst
+++ b/docs/api/resource.rst
@@ -1,9 +1,9 @@
-.. _resource:
+.. _api-resource:
 
 Resource
 ========
 
-.. py:module:: altapay.resource
+.. py:module:: altapay
 
 .. autoclass:: Resource
     :members:

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,0 +1,12 @@
+.. _api-utils:
+
+Utilities
+=========
+
+.. py:module:: altapay.utils
+
+.. autofunction:: etree_to_dict
+
+.. autofunction:: http_build_query
+
+.. autofunction:: to_pythonic_name

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ import shlex
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'alabaster'
 ]
 
 sys.path.insert(0, os.path.join(os.path.abspath('..')))
@@ -118,7 +119,18 @@ html_theme_options = {
     'github_user': 'coolshop-com',
     'github_repo': 'AltaPay',
     'github_button': True,
-    'travis_button': True
+    'description': (
+        'This is an unofficial Python SDK for AltaPay (formerly Pensio).')
+}
+
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',
+        'searchbox.html',
+        'donate.html',
+    ]
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/guide/backoffice.rst
+++ b/docs/guide/backoffice.rst
@@ -1,0 +1,4 @@
+.. _guide-backoffice:
+
+Backoffice
+==========

--- a/docs/guide/create_payment.rst
+++ b/docs/guide/create_payment.rst
@@ -1,0 +1,87 @@
+.. _guide-create-payment:
+
+Create Payment
+==============
+
+Creating a new :py:class:`altapay.Payment` resource will result in an URL that you should redirect your customer to.
+
+It is in creating the payment you describe what payment options the customer should have, the total order amount, and other optional parameters. The parameters you use will depend on the terminal you wish to use.
+
+.. _guide-create-payment-basic-payment:
+
+Basic Payment
++++++++++++++
+
+In the most basic form, a :py:class:`altapay.Payment` object requires a terminal, order ID amount and currency. Creating such payment will look something like this:
+
+.. code :: python
+
+    from altapay import API, Payment
+
+    # Create an API object using your credentials
+    api = API(...)
+
+    # Create an empty payment object using the API
+    payment = Payment(api=api)
+
+    # Create a new payment using the AltaPay service.
+    payment.create('Terminal Name', 'OrderID1234', 13.95, 'EUR')
+
+    if payment.success:
+        # Assuming a function redirect() which redirects the customer
+        redirect(payment.url)
+    else:
+        raise Exception('Payment not successful')
+
+This payment is, of course, only very basic, and will only render the standard AltaPay payment form - but it will work. There are, of course, a lot of configuration options.
+
+For a detailed view of these, see the AltaPay API documentation for :samp:`API/createPaymentRequest`, bearing in mind the conventions described in :ref:`guide-introduction`.
+
+.. _guide-create-payment-complex-payment:
+
+Complex Payment
++++++++++++++++
+
+Using only the basic payment information will not get you very far. In reality, you are going to want to customize it to your liking, for example using a custom callback form and more detailed order and customer information. Our recommendation would be to always include as much information as possible regarding the order and the customer, since you will be covered for more of the possible terminals this way.
+
+This following example implements a lot of the different possibilities using the AltaPay service.
+
+.. code :: python
+
+    from altapay import API, Payment
+
+    api = API(...)
+    payment = Payment(api=api)
+
+    # We can pass all of the optional parameters as keyword arguments to
+    # the payment creation
+    params = {
+        'config': {
+            'callback_form': 'https://your-callback-form/form.html',
+        },
+        'transaction_info': [
+            'ArbitraryInfo1',
+            'ArbitraryInfo2'
+        ],
+        'customer_info': {
+            'billing_postal': '9400',
+            'billing_address': 'Address 12',
+            'billing_firstname': 'First name',
+            'billing_lastname': 'Last name',
+            'email': 'foo@bar.com'
+        },
+        'orderLines': [
+            {
+                'description': 'Description of the order line',
+                'itemId': '123456',
+                'quantity': 1
+            }
+        ]
+    }
+
+    payment.create('Terminal name', 'OrderID1234', 13.95, 'EUR', **params)
+
+    if payment.success:
+        redirect(payment.url)
+
+The above example obviously is not complete; there are many more parameters which are described in the AltaPay API documentation. Remember: more data is better, and will result in more terminals working.

--- a/docs/guide/introduction.rst
+++ b/docs/guide/introduction.rst
@@ -1,0 +1,32 @@
+.. _guide-introduction:
+
+Introduction
+============
+
+The Python SDK for AltaPay attempts to make it possible to work with the AltaPay API in the most Pythonic way possible. As such, several things are slightly different, and will not match exactly to what is described in the documentation.
+
+Noticeable differences are;
+
+- The Python SDK is object based, with an object per resource (e.g. an :py:class:`altapay.Payment` resource). Actions are performed on these objects in order to carry out API calls in the AltaPay API
+- To make the naming scheme feel more Pythonic, names returned by AltaPay is mapped accordingly; e.g. ``CamelCase`` becomes ``camel_case``
+- In the AltaPay API, when you send parameters to calls, and these contains nested structures in the form of either arrays or hashed values, the PHP query parameter syntax is used. In the Python SDK, this has been changed to lists and dictionaries for easier use. For a concrete use case, see the payment creation examples
+
+The API object
+++++++++++++++
+
+All resources that expose AltaPay functionality requires an :py:class:`altapay.API` object to be passed. The object is what authenticates you to the AltaPay API service, and is also what determines whether or not you should connect to the test service or the production service.
+
+.. code:: python
+
+    from altapay import API
+
+    # Create an API object that will connect to the test service
+    api = API(mode='test', account='account', password='password')
+
+    # If you instead want to create an object for production calls, simply
+    # change the mode
+    api = API(mode='production', account='account', password='password')
+
+Optionally, the environment variables :samp:`ALTAPAY_ACCOUNT_NAME` and :samp:`ALTAPAY_ACCOUNT_PASSWORD` can be used instead of passing the account and password directly to :py:class:`altapay.API`.
+
+Making an instance of :py:class:`altapay.API` will automatically attempt to do the login service call in the AltaPay API, which will verify your account and password. This is reccomended behaviour by the AltaPay service, and will only happen when the instance is created. If this is not the desired behaviour, an optional parameter :samp:`auto_login` can be set to :samp:`False` to disable the automatic login. If you do this, you should call :py:func:`altapay.API.login()` yourself before you do any other calls.

--- a/docs/guide/logging.rst
+++ b/docs/guide/logging.rst
@@ -1,0 +1,4 @@
+.. _guide-logging:
+
+Logging
+=======

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,14 +3,13 @@ AltaPay Python SDK
 
 This is an unofficial Python SDK for AltaPay (formerly Pensio), https://altapay.com/. The SDK is maintained by Coolshop.com, https://www.coolshop.com/.
 
-**This is an incomplete, in-development version of the SDK. Do not use unless you know what you are doing**
-
 The AltaPay Python SDK attempts to consume the AltaPay API in a clean and Pythonic way, without getting in your way. As a result, you will often find yourself thinking that the API is similar, but has been changed ever so slightly to make it easier for you to use.
 
 As a simple example, once you have your API credentials and a terminal, it is very easy to create a payment in the test environment and get a redirect URL to the payment page.
 
 .. code:: python
 
+    >>> from altapay import API, Payment
     >>> api = API(mode='test', account='login', password='password')
     >>> payment = Payment(api=api)
     >>> payment.create('Test Terminal', 1234567, 13.95, 'EUR')
@@ -22,7 +21,13 @@ As a simple example, once you have your API credentials and a terminal, it is ve
 Guide
 +++++
 
-To come
+.. toctree::
+   :maxdepth: 2
+
+   guide/introduction
+   guide/create_payment
+.. guide/backoffice
+.. guide/logging
 
 
 API Documentation
@@ -31,10 +36,11 @@ API Documentation
 .. toctree::
    :maxdepth: 2
 
-   api
-   resource
-   payment
-   exceptions
+   api/api
+   api/resource
+   api/payment
+   api/exceptions
+   api/utils
 
 
 Indices and tables

--- a/docs/payment.rst
+++ b/docs/payment.rst
@@ -1,9 +1,0 @@
-.. _payment:
-
-Payment
-=======
-
-.. py:module:: altapay.payment
-
-.. autoclass:: Payment
-    :members:

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,20 @@
+import re
+
 from setuptools import setup, find_packages
 
 
 def get_version():
-    return __import__('altapay').__version__
+    with open('altapay/__init__.py') as f:
+        return re.search(
+            r'^__version__\s*=\s*[\'"]([^\']*)[\'"]', f.read(),
+            re.MULTILINE).group(1)
 
 
 def get_url():
-    return __import__('altapay').__github_url__
+    with open('altapay/__init__.py') as f:
+        return re.search(
+            r'^__github_url__\s*=\s*[\'"]([^\']*)[\'"]', f.read(),
+            re.MULTILINE).group(1)
 
 version = get_version()
 github_url = get_url()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-import unittest
-
 import responses
-from altapay import exceptions
-from altapay.api import API
+from altapay import API, exceptions
 
 from .test_cases import TestCase
 
@@ -15,9 +12,6 @@ class APITest(TestCase):
     def setUp(self):
         self.api = API(mode='test', auto_login=False)
 
-    # Index is listed as being callable without authentication, but this seems
-    # to not be the case. AltaPay has been notified.
-    @unittest.skip
     def test_index_successful(self):
         self.assertEqual(self.api.index().success, True)
 
@@ -79,4 +73,13 @@ class APITest(TestCase):
             body='', status=402, content_type='application/xml')
         with self.assertRaises(exceptions.ResponseStatusError):
             self.api._request(
-                self.get_api_url('API/notReal'), 'GET', params={}, headers={})
+                self.get_api_url('API/notReal'), 'GET')
+
+    @responses.activate
+    def test_http_response_code_500(self):
+        responses.add(
+            responses.GET, self.get_api_url('API/notReal'),
+            body='', status=500, content_type='application/xml')
+        with self.assertRaises(exceptions.ServerError):
+            self.api._request(
+                self.get_api_url('API/notReal'), 'GET')

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import responses
-from altapay.api import API
-from altapay.payment import Payment
+from altapay import API, Payment
 
 from .test_cases import TestCase
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from altapay.resource import Resource
+from altapay import Resource
 
 from .test_cases import TestCase
 


### PR DESCRIPTION
- More tests added to attempt to achieve full coverage
- Code that couldn't be reliably reached through tests has been removed
- Restructured docs and added a small getting started guide
- Moved the main SDK objects into the altapay module namespace
- Added the option for creating complex payments (in reality, complex
  resources) in a Pythonic way, through lists and dictionaries, which
will be converted to a format the AltaPay API understands