### PR TITLE
Add correct response error handling in Resource

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,19 @@
 Change Log
 ----------
 
-0.1.dev1 (2015-12-23)
+0.1.dev2 (2015-01-XX)
 +++++++++++++++++++++
+
+- NYI
+
+0.1.dev1 (2015-01-05)
++++++++++++++++++++++
+
+- Complex payments are now possible. This means it is now possible to send detailed payment information in a Pythonic way using just lists and dictionaries, instead of the PHP style query params syntax
+- Documentation now includes a small guide for available parts of the SDK, which will make is easier to get started easily without reading the raw API documentation
 
 0.1.dev0 (2015-12-18)
 +++++++++++++++++++++
 
-- Basic API connection class implemented in `altapay.api.API`
-- Basic Payment class implemented in `altapay.payment.Payment` which is currently mainly for creating a very basic payment request with the AltaPay service
+- Basic API connection class implemented in ``altapay.api.API``
+- Basic Payment class implemented in ``altapay.payment.Payment`` which is currently mainly for creating a very basic payment request with the AltaPay service

--- a/altapay/utils.py
+++ b/altapay/utils.py
@@ -21,6 +21,12 @@ def to_pythonic_name(name):
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
+def to_pythonic_dict(dictionary):
+    return {
+        to_pythonic_name(k): v for k, v in dictionary.items()
+    }
+
+
 def etree_to_dict(tree):
     """
     *Note: This is an internal API and may be changed without notice.*

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -34,9 +34,20 @@ class ResponseTest(TestCase):
 
     def test_error(self):
         resource = Resource()
-        error = {'abc': 'abc'}
-        resource.__header__['error'] = error
-        self.assertEqual(resource.error, error)
+        resource.merge_response({
+            'APIResponse': {
+                '@version': 0,
+                'Header': {
+                    'ErrorCode': 0,
+                    'ErrorMessage': ''
+                },
+                'Body': {}
+            }})
+        self.assertEqual(
+            resource.error, {
+                'code': 0,
+                'message': ''
+            })
 
     def test_attribute_does_not_exist(self):
         resource = Resource()
@@ -46,7 +57,15 @@ class ResponseTest(TestCase):
     def test_success(self):
         resource = Resource()
         self.assertEqual(resource.success, True)
-        resource.__header__['error'] = {'abc': 'abc'}
+        resource.merge_response({
+            'APIResponse': {
+                '@version': 0,
+                'Header': {
+                    'ErrorCode': 1,
+                    'ErrorMessage': 'Some Error Message'
+                },
+                'Body': {}
+            }})
         self.assertEqual(resource.success, False)
 
     def test_create_from_response(self):


### PR DESCRIPTION
The previous implementation was not complete, whish is why #11 was an
issue. This should now be resolved, and the property error on a Resource
now contains both a code and a message. In case of no errors, the code
will always be 0, which is reflected in the success property.