### PR TITLE
Enable the option of running in production mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 **Bugfixes**
 
 - Fixed a bug where specifying a non-existing terminal while creating an ``altapay.Payment`` object would result in ``altapay.Payment.success`` returning ``True``
+- Fixed a bug where running in production mode was not possible. It is now possible by specifying a shop name when instantiating the API
 
 0.1.dev1 (2015-01-05)
 +++++++++++++++++++++

--- a/altapay/exceptions.py
+++ b/altapay/exceptions.py
@@ -9,6 +9,12 @@ class AltaPayException(Exception):
     pass
 
 
+class APIError(AltaPayException):
+    """
+    Raised if the API object could not be configured with the given parameters.
+    """
+
+
 class UnauthorizedAccessError(AltaPayException):
     """
     Raised on unauthorized errors against the AltaPay service.

--- a/docs/guide/introduction.rst
+++ b/docs/guide/introduction.rst
@@ -25,8 +25,12 @@ All resources that expose AltaPay functionality requires an :py:class:`altapay.A
 
     # If you instead want to create an object for production calls, simply
     # change the mode
-    api = API(mode='production', account='account', password='password')
+    api = API(
+        mode='production', account='account', password='password',
+        shop_name='test-shop')
 
 Optionally, the environment variables :samp:`ALTAPAY_ACCOUNT_NAME` and :samp:`ALTAPAY_ACCOUNT_PASSWORD` can be used instead of passing the account and password directly to :py:class:`altapay.API`.
+
+The :samp:`shop_name` parameter will be used to populate the AltaPay service URL, and is not required when running in test mode.
 
 Making an instance of :py:class:`altapay.API` will automatically attempt to do the login service call in the AltaPay API, which will verify your account and password. This is reccomended behaviour by the AltaPay service, and will only happen when the instance is created. If this is not the desired behaviour, an optional parameter :samp:`auto_login` can be set to :samp:`False` to disable the automatic login. If you do this, you should call :py:func:`altapay.API.login()` yourself before you do any other calls.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,8 +62,16 @@ class APITest(TestCase):
             API()
 
     def test_missing_url(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(exceptions.APIError):
             API(auto_login=False, mode='notworking')
+
+    def test_production_missing_shop_name(self):
+        with self.assertRaises(exceptions.APIError):
+            API(auto_login=False, mode='production')
+
+    def test_production_shop_name(self):
+        api = API(auto_login=False, mode='production', shop_name='test-shop')
+        self.assertIn('test-shop', api.url)
 
     @responses.activate
     def test_http_response_code_not_supported(self):


### PR DESCRIPTION
Enable hanlding of the shop_name option to API, which in turn will make
it possible to properly run in production mode.

Issue #11