### PR TITLE
Fix a bug where the key might be in Python format

### DIFF
--- a/altapay/callback.py
+++ b/altapay/callback.py
@@ -23,10 +23,13 @@ class Callback(Resource):
             data = [data]
 
         transaction_set = data
+
         if auth_type:
             transaction_set = [
                 transaction for transaction in data
-                if transaction['AuthType'] == auth_type
+                if auth_type in (
+                    transaction.get('AuthType', ''),
+                    transaction.get('auth_type', ''))
             ]
 
         return [

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -48,7 +48,7 @@ class PaymentTest(TestCase):
     def test_transaction_set_single(self):
         callback = Callback.from_xml_callback(self.response_single_as_str)
 
-        transactions = callback.transactions()
+        transactions = callback.transactions(auth_type='subscription_payment')
 
         self.assertIsInstance(transactions, list)
         self.assertEqual(len(transactions), 1)


### PR DESCRIPTION
The previous test cases did not do a filter on the single transaction.
This means a certain bug wasn't tested, where the dictionary would be
Pythonified in cases where there was only one transaction.

Reported in Issue #25