### PR TITLE
Fix possible KeyError on Transaction lookup

### DIFF
--- a/altapay/__init__.py
+++ b/altapay/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'altapay'
-__version__ = '0.1.dev3'
+__version__ = '1.0.dev4'
 __author__ = 'Coolshop.com'
 __license__ = 'MIT'
 __github_url__ = 'https://github.com/coolshop-com/AltaPay'

--- a/altapay/exceptions.py
+++ b/altapay/exceptions.py
@@ -43,3 +43,9 @@ class MultipleResourcesError(AltaPayException):
     Raised if more than one Resource was found when attempting to look up a
     single resource.
     """
+
+
+class ResourceNotFoundError(AltaPayException):
+    """
+    Raised if a resource is not found.
+    """

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import responses
 from altapay import API, Transaction
-from altapay.exceptions import MultipleResourcesError
+from altapay.exceptions import MultipleResourcesError, ResourceNotFoundError
 
 from .test_cases import TestCase
 
@@ -10,6 +10,16 @@ from .test_cases import TestCase
 class PaymentTest(TestCase):
     def setUp(self):
         self.api = API(mode='test', auto_login=False)
+
+    @responses.activate
+    def test_find_transaction_failure(self):
+        responses.add(
+            responses.GET, self.get_api_url('API/payments'),
+            body=self.load_xml_response('200_find_transaction_failure.xml'),
+            status=200, content_type='application/xml')
+
+        with self.assertRaises(ResourceNotFoundError):
+            Transaction.find('TEST-TRANSACTION-ID', self.api)
 
     @responses.activate
     def test_find_transaction_success(self):

--- a/tests/xml/200_find_transaction_failure.xml
+++ b/tests/xml/200_find_transaction_failure.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<APIResponse version="20151228">
+    <Header>
+        <Date>2016-02-02T15:51:39+01:00</Date>
+        <Path>API/payments?transaction_id=TEST-TRANSACTION-ID</Path>
+        <ErrorCode>0</ErrorCode>
+        <ErrorMessage/>
+    </Header>
+    <Body>
+        <Result/>
+        <CardHolderMessageMustBeShown>false</CardHolderMessageMustBeShown>
+        <ResultFilter>
+            <TransactionIdEquals>TEST-TRANSACTION-ID</TransactionIdEquals>
+        </ResultFilter>
+    </Body>
+</APIResponse>


### PR DESCRIPTION
Fix a bug where looking up a non existent transaction would result in a
KeyError.

Also bump to 1.0.dev4 for next release.

Issue #32