### PR TITLE
Add FundingList and Funding objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ----------
 
+1.2.0 (2016-04-19)
+++++++++++++++++++
+
+**Features***
+
+- Added ``altapay.FundingList`` and ``altapay.Funding``. These two objects will interact with the funding list features of AltaPay, and will allow you to both list all of your funding files, as well as download individual files. Currently no guide section is written on the subject, but full API documentation is available.
+
 1.1.0 (2016-04-12)
 ++++++++++++++++++
 

--- a/altapay/__init__.py
+++ b/altapay/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'altapay'
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 __author__ = 'Coolshop.com'
 __license__ = 'MIT'
 __github_url__ = 'https://github.com/coolshop-com/AltaPay'
@@ -10,6 +10,7 @@ __api_base_url__ = {
 
 from altapay.api import API  # NOQA
 from altapay.callback import Callback  # NOQA
+from altapay.funding import Funding, FundingList  # NOQA
 from altapay.payment import Payment  # NOQA
 from altapay.resource import Resource  # NOQA
 from altapay.transaction import Transaction  # NOQA

--- a/altapay/api.py
+++ b/altapay/api.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import ssl
+from io import BytesIO
 from xml.etree import ElementTree
 
 import requests
@@ -192,3 +193,14 @@ class API(object):
             params=utils.http_build_query(parameters),
             data=utils.http_build_query_dict(data),
             headers=headers or self._headers())
+
+    def download(self, resource, parameters={}, headers={}):
+        """
+        Downloads a resource. Acts as a custom HTTP GET.
+        Not that it is considered the callers responsibility to actually
+        flush/close the stream.
+        """
+        response = requests.get(
+            resource, params=utils.http_build_query(parameters), stream=True,
+            headers=headers or self._headers(), auth=self._auth)
+        return BytesIO(response.content)

--- a/altapay/funding.py
+++ b/altapay/funding.py
@@ -1,0 +1,89 @@
+from __future__ import absolute_import, unicode_literals
+
+import os
+
+from altapay import exceptions
+from altapay.callback import Callback
+from altapay.resource import Resource
+
+
+class Funding(Resource):
+    def download(self, save_to):
+        """
+        Download the CSV funding file.
+
+        :arg save_to: the path to save the funding file to. The filename will
+            match the name of the file at AltaPay, and will have the extension
+            .csv attached.
+
+        :rtype: a string with the complete filepath to the CSV funding file
+        """
+        filepath = os.path.join(save_to, self.filename) + '.csv'
+        with open(filepath, 'wb') as fd:
+            fd.write(self.content())
+        return filepath
+
+    def content(self):
+        """The funding file content as bytes."""
+        return self.api.download(self.download_link).read()
+
+
+class FundingList(object):
+    _fundings = []
+    _current_page = 0
+    _api = None
+    _number_of_pages = None
+
+    def __init__(self, api):
+        """
+        Retrieve the first page of the funding list.
+
+        :arg api: An API object which will be used for AltaPay communication.
+        """
+        self._api = api
+        self._load_page()
+
+    def _load_page(self):
+        response = self._api.post(
+            'API/fundingList/', data={'page': self._current_page}
+        )['APIResponse']
+        callback = Callback.from_xml_callback(response)
+        self._fundings = [
+            Funding(
+                response['@version'], response['Header'], funding,
+                api=self._api)
+            for funding in callback.fundings['funding']
+        ]
+        self._number_of_pages = callback.fundings['@number_of_pages']
+
+    def next_page(self):
+        """
+        Loads the next page of funding files.
+
+        Raises:
+            :py:class:`altapay.exceptions.ResourceNotFoundError`:
+            if the next page is not available, typically meaning you have
+            scrolled past the available pages.
+        """
+        # The first current page is called 0
+        if self._current_page + 1 > self._number_of_pages - 1:
+            raise exceptions.ResourceNotFoundError(
+                'Requested funding page does not exist.')
+        self._current_page += 1
+        self._load_page()
+
+    @property
+    def fundings(self):
+        """
+        :py:class:`altapay.Funding` objects on the current page of
+        funding files.
+        """
+        return self._fundings
+
+    @property
+    def number_of_pages(self):
+        """
+        Returns the total amount of pages with fundings. Each page can hold
+        100 fundings.
+        """
+        return self._number_of_pages

--- a/altapay/transaction.py
+++ b/altapay/transaction.py
@@ -11,8 +11,8 @@ class Transaction(Resource):
         """
         Find exactly one transaction by a transaction ID.
 
-        :param transaction_id: ID of the transaction in AltaPay
-        :param api: An API object which will be used for AltaPay communication.
+        :arg transaction_id: ID of the transaction in AltaPay
+        :arg api: An API object which will be used for AltaPay communication.
 
         :rtype: :py:class:`altapay.Transaction`
         """
@@ -39,7 +39,7 @@ class Transaction(Resource):
         """
         Capture a reservation on a transaction.
 
-        :param \*\*kwargs: used for optional capture parameters, see the
+        :arg \*\*kwargs: used for optional capture parameters, see the
             AltaPay documentation for a full list.
             Note that you will need to use lists and dictionaries to map the
             URL structures from the AltaPay documentation into these kwargs.
@@ -65,7 +65,7 @@ class Transaction(Resource):
         If amount is not sent as an optinal parameter, the amount specified in
         the original setup of the subscription will be used.
 
-        :param \*\*kwargs: used for optional charge subscription parameters,
+        :arg \*\*kwargs: used for optional charge subscription parameters,
             see the AltaPay documentation for a full list.
             Note that you will need to use lists and dictionaries to map the
             URL structures from the AltaPay documentation into these kwargs.
@@ -91,7 +91,7 @@ class Transaction(Resource):
         If amount is not sent as an optinal parameter, the amount specified in
         the original setup of the subscription will be used.
 
-        :param \*\*kwargs: used for optional reserve subscription parameters,
+        :arg \*\*kwargs: used for optional reserve subscription parameters,
             see the AltaPay documentation for a full list.
             Note that you will need to use lists and dictionaries to map the
             URL structures from the AltaPay documentation into these kwargs.

--- a/docs/api/funding.rst
+++ b/docs/api/funding.rst
@@ -1,0 +1,16 @@
+.. _api-funding:
+
+Funding
+=======
+
+.. py:module:: altapay
+
+.. autoclass:: Funding
+    :show-inheritance:
+    :members:
+
+FundingList
+===========
+
+.. autoclass:: FundingList
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ API Documentation
    api/payment
    api/callback
    api/transaction
+   api/funding
    api/exceptions
    api/utils
 

--- a/tests/test_funding.py
+++ b/tests/test_funding.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import, unicode_literals
+import os
+
+import responses
+from altapay import API, Funding, FundingList, exceptions
+
+from .test_cases import TestCase
+
+
+class FundingListTest(TestCase):
+    @responses.activate
+    def setUp(self):
+        self.api = API(mode='test', auto_login=False)
+        responses.add(
+            responses.POST, self.get_api_url('API/fundingList/'),
+            body=self.load_xml_response('200_funding_list_page_0.xml'),
+            status=200, content_type='application/xml')
+        self.funding_list = FundingList(api=self.api)
+
+    def test_fundings(self):
+        self.assertEqual(len(self.funding_list.fundings), 2)
+        for funding in self.funding_list.fundings:
+            self.assertIsInstance(funding, Funding)
+
+    def test_number_of_pages(self):
+        self.assertEqual(self.funding_list.number_of_pages, 2)
+
+    @responses.activate
+    def test_next_page(self):
+        responses.add(
+            responses.POST, self.get_api_url('API/fundingList/'),
+            body=self.load_xml_response('200_funding_list_page_0.xml'),
+            status=200, content_type='application/xml')
+        self.assertEqual(self.funding_list._current_page, 0)
+        self.funding_list.next_page()
+        self.assertEqual(self.funding_list._current_page, 1)
+        self.assertEqual(len(self.funding_list.fundings), 2)
+
+        # Test it's not possible to scroll past the end of the funding list
+        with self.assertRaises(exceptions.ResourceNotFoundError):
+            self.funding_list.next_page()
+
+
+class FundingTest(TestCase):
+    @responses.activate
+    def setUp(self):
+        self.api = API(mode='test', auto_login=False)
+        responses.add(
+            responses.POST, self.get_api_url('API/fundingList/'),
+            body=self.load_xml_response('200_funding_list_page_0.xml'),
+            status=200, content_type='application/xml')
+        self.funding_list = FundingList(api=self.api)
+
+    @responses.activate
+    def test_content(self):
+        responses.add(
+            responses.GET, self.get_api_url('API/fundingDownload'),
+            body=self.load_xml_response('200_funding.csv'),
+            status=200, content_type='text/plain')
+        funding = self.funding_list.fundings[0]
+        content = funding.content()
+        self.assertGreater(len(content), 1)
+
+    @responses.activate
+    def test_download(self):
+        responses.add(
+            responses.GET, self.get_api_url('API/fundingDownload'),
+            body=self.load_xml_response('200_funding.csv'),
+            status=200, content_type='text/plain')
+        funding = self.funding_list.fundings[0]
+        filepath = funding.download('./')
+        self.assertEqual(filepath, './CreatedByTest.csv')
+        content = None
+        with open(filepath, 'rb') as fd:
+            content = fd.read()
+        self.assertEqual(content, funding.content())
+        os.remove(filepath)

--- a/tests/xml/200_funding.csv
+++ b/tests/xml/200_funding.csv
@@ -1,0 +1,2 @@
+Date;Type;ID;"Reconciliation Identifier";Payment;Order;Terminal;Shop;"Transaction Currency";"Transaction Amount";"Exchange Rate";"Settlement Currency";"Settlement Amount";"Fixed Fee";"Fixed Fee VAT";"Rate Based Fee";"Rate Based Fee VAT"
+"2010-09-22 00:00:00";payment;5;3f664acc-c71d-45e6-8c6a-a15838451a77;5;"settlement functional4c9a127b159a0";"AltaPay Test Terminal";"AltaPay Functional Test Shop";EUR;50.00;100.000000;EUR;50.00;;;;

--- a/tests/xml/200_funding_list_page_0.xml
+++ b/tests/xml/200_funding_list_page_0.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<APIResponse version="20100929">
+   <Header>
+      <Date>2010-09-29T12:34:56+02:00</Date>
+      <Path>API/fundingList</Path>
+      <ErrorCode>0</ErrorCode>
+      <ErrorMessage></ErrorMessage>
+   </Header>
+   <Body>
+      <Fundings numberOfPages="2">
+         <Funding>
+            <Filename>CreatedByTest</Filename>
+            <ContractIdentifier>1234567890123456</ContractIdentifier>
+            <Shops>
+               <Shop>AltaPay Functional Test Shop</Shop>
+               <Shop>AltaPay Functional Test Shop Two</Shop>
+            </Shops>
+            <Acquirer>TestAcquirer</Acquirer>
+            <FundingDate>2010-09-26</FundingDate>
+            <Amount>50.00 EUR</Amount>
+            <CreatedDate>2010-09-27</CreatedDate>
+            <DownloadLink>
+               https://testgateway.altapaysecure.com/merchant/API/fundingDownload?id=1
+            </DownloadLink>
+         </Funding>
+         <Funding>
+            <Filename>CreatedByTest2</Filename>
+            <ContractIdentifier>1234567890123456</ContractIdentifier>
+            <Shops>
+               <Shop>AltaPay Functional Test Shop</Shop>
+               <Shop>AltaPay Functional Test Shop Two</Shop>
+            </Shops>
+            <Acquirer>TestAcquirer</Acquirer>
+            <FundingDate>2010-09-26</FundingDate>
+            <Amount>50.00 EUR</Amount>
+            <CreatedDate>2010-09-27</CreatedDate>
+            <DownloadLink>
+               https://testgateway.altapaysecure.com/merchant/API/fundingDownload?id=2
+            </DownloadLink>
+         </Funding>
+      </Fundings>
+   </Body>
+</APIResponse>


### PR DESCRIPTION
Added ``altapay.FundingList`` and ``altapay.Funding``. These two objects will interact with the funding list features of AltaPay, and will allow you to both list all of your funding files, as well as download individual files. Currently no guide section is written on the subject, but full API documentation is available.